### PR TITLE
update package.json to allow requiring from other scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "engines": {
     "node": ">=0.10.0"
   },
+  "main": "sass-graph.js",
   "directories": {
     "bin": "./bin"
   },


### PR DESCRIPTION
There is no main in package.json. Setting this to the correct file will allow other scripts to correctly require this plugin.
