### PR TITLE
Normalize paths so files don't have multiple entries

### DIFF
--- a/sass-graph.js
+++ b/sass-graph.js
@@ -19,12 +19,12 @@ function parseImports(content) {
 }
 
 // resolve a sass module to a path
-function resolveSassPath(path, loadPaths) {
+function resolveSassPath(sassPath, loadPaths) {
   // trim any file extensions
-  path = path.replace(/\.\w+$/, '');
+  sassPath = sassPath.replace(/\.\w+$/, '');
   // check all load paths
   for(var p in loadPaths) {
-    var scssPath = loadPaths[p] + "/" + path + ".scss"
+    var scssPath = path.normalize(loadPaths[p] + "/" + sassPath + ".scss");
     if (fs.existsSync(scssPath)) {
       return scssPath;
     }


### PR DESCRIPTION
Previously, performing an import such as `../vars.scss` produced two entries in the index, `PATH/vars.scss` and `PATH/folder/../vars.scss`.  This commit normalizes paths so the duplicate entries are removed and all entries can be found at one index point.
