### PR TITLE
Fix some issues in Windows

### DIFF
--- a/sass-graph.js
+++ b/sass-graph.js
@@ -46,7 +46,7 @@ function Graph(loadPaths, dir) {
   if(dir) {
     var graph = this;
     _(glob.sync(dir+"/**/*.scss", {})).forEach(function(file) {
-      graph.addFile(file);
+      graph.addFile(path.resolve(file));
     });
   }
 }


### PR DESCRIPTION
This fixes a couple of issues that currently prevent certain parts of sass-graph from working properly on Windows:

1) When importing a mixin, the regex that prepends "_" to the filename expects only forward slashes in the path. Replacing the regex with path methods makes it work regardless of which directory separators are used.
2) node-glob always returns paths with forward slashes, this leads to duplicate entries in the resulting imports in Windows. Using node's path.resolve makes the directory separators consistent.
