### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ All notable changes to this project will be documented in this file.
 
 ### Tests
 
+## [2.0.0]
+### BREAKING CHANGES
+- `.sass` files are not included in the graph by default. Use the `-e .sass` flag.
+
+### Features
+- Configurable file extensions - [@dannymidnight](https://github.com/dannymidnight), [@xzyfer](https://github.com/xzyfer)
+
+### Fixed
+- Prioritize cwd when resolving load paths - [@schnerd](https://github.com/schnerd)
+
+### Tests
+- Added test for prioritizing cwd when resolving load paths - [@xzyfer](https://github.com/xzyfer)
+
 ## [1.3.0]
 ### Features
 - Add support for indented syntax - [@vegetableman](https://github.com/vegetableman)

--- a/bin/sassgraph
+++ b/bin/sassgraph
@@ -83,8 +83,9 @@ try {
   }
 
   var graph = require('../').parseDir(directory, {
+    extensions: argv.extensions,
     loadPaths: loadPaths,
-    });
+  });
 
   if(argv.json) {
     console.log(JSON.stringify(graph.index, null, 4));

--- a/bin/sassgraph
+++ b/bin/sassgraph
@@ -1,80 +1,115 @@
 #!/usr/bin/env node
+var fs = require('fs');
+var path = require('path');
 
-var path = require("path");
-var fs = require("fs");
-var program = require("commander");
+var command, directory, file;
 
-var sassGraph = require("../sass-graph");
-var package = require("../package.json");
+var yargs = require('yargs')
+    .usage('Usage: $0 <command> [options] <dir> [file]')
+    // .demand(1)
 
-program.version("Sass Graph Version " + package.version);
+    .command('ancestors', 'Output the ancestors')
+    .command('descendents', 'Output the descendents')
 
-program
-  .usage([
-      "[OPTIONS] DIR FILE",
-      program._version,
-      "DIR is a directory containing scss files. FILE is a scss file to analyze."
-    ].join("\n\n  "))
-  .option("-I <dir>", "Add dir to the sass load path. Multiple dirs can be comma delimited.")
-  .option("-a", "Print ancestors")
-  .option("-d", "Print descendents")
-  .option("--json", "Prints the index in json")
-  .option("-v, --version", "Display version information")
-  .parse(process.argv);
+    .example('$0 ancestors -I src src/ src/_footer.scss', 'outputs the ancestors of src/_footer.scss')
 
-if ( ! program.args.length) {
-  program.help();
+    .option('I', {
+      alias: 'load-path',
+      default: [process.cwd()],
+      describe: 'Add directories to the sass load path',
+      type: 'array',
+    })
+
+    .option('e', {
+      alias: 'extensions',
+      default: ['scss', 'css'],
+      describe: 'File extensions to include in the graph',
+      type: 'array',
+    })
+
+    .option('j', {
+      alias: 'json',
+      default: false,
+      describe: 'Output the index in json',
+      type: 'bool',
+    })
+
+    .version(function() {
+      return require('../package').version;
+    })
+    .alias('v', 'version')
+
+    .help('h')
+    .alias('h', 'help');
+
+var argv = yargs.argv;
+
+if (argv._.length === 0) {
+  yargs.showHelp();
+  process.exit(1);
 }
 
-var loadPaths = [];
-
-// load paths are comma delimited
-if(program.I) {
-  loadPaths = program.I.split(/,/).map(function(f){
-    return path.resolve(f);
-  });
+if (['ancestors', 'descendents'].indexOf(argv._[0]) !== -1) {
+  command = argv._.shift();
 }
 
-// SASS_PATH can contain a colon delimited list of paths
-if(process.env.SASS_PATH) {
-  loadPaths = loadPaths.concat(process.env.SASS_PATH.split(/:/).map(function(f){
-    return path.resolve(f);
-  }));
+if (argv._ && path.extname(argv._[0]) === '') {
+  directory = argv._.shift();
 }
 
-var sassDir = program.args[0];
-var sassFile = program.args[1];
+if (argv._ && path.extname(argv._[0])) {
+  file = argv._.shift();
+}
+
 
 try {
-  if(!fs.lstatSync(sassDir).isDirectory()) {
-    console.error("%s must be a directory", sassDir);
-    process.exit(1);
+  if (!directory) {
+    throw new Error('Missing directory');
   }
 
-  var graph = sassGraph.parseDir(sassDir, { loadPaths: loadPaths });
+  if (!command && !argv.json) {
+    throw new Error('Missing command');
+  }
 
-  if(program.json) {
+  if (!file && (command === 'ancestors' || command === 'descendents')) {
+    throw new Error(command + ' command requires a file');
+  }
+
+  var loadPaths = argv.loadPath;
+  if(process.env.SASS_PATH) {
+    loadPaths = loadPaths.concat(process.env.SASS_PATH.split(/:/).map(function(f) {
+      return path.resolve(f);
+    }));
+  }
+
+  var graph = require('../').parseDir(directory, {
+    loadPaths: loadPaths,
+    });
+
+  if(argv.json) {
     console.log(JSON.stringify(graph.index, null, 4));
     process.exit(0);
   }
 
-  if (program.A) {
-    graph.visitAncestors(path.resolve(sassFile), function(f) {
+  if (command === 'ancestors') {
+    graph.visitAncestors(path.resolve(file), function(f) {
       console.log(f);
     });
   }
-  if (program.D) {
-    graph.visitDescendents(path.resolve(sassFile), function(f) {
-      console.log(f);
-    });
-  }
-  if (program.B) {
-    graph.visitDescendents(path.resolve(sassFile), function(f) {
+
+  if (command === 'descendents') {
+    graph.visitDescendents(path.resolve(file), function(f) {
       console.log(f);
     });
   }
 } catch(e) {
-  console.log(e);
+  if (e.code === 'ENOENT') {
+    console.error('Error: no such file or directory "' + e.path + '"');
+  }
+  else {
+    console.log('Error: ' + e.message);
+  }
+
   // console.log(e.stack);
   process.exit(1);
 }

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "graph"
   ],
   "dependencies": {
-    "commander": "^2.6.0",
     "glob": "^4.3.4",
-    "lodash": "^2.4.1"
+    "lodash": "^2.4.1",
+    "yargs": "^3.8.0"
   },
   "devDependencies": {
     "assert": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "dependencies": {
     "glob": "^5.0.5",
-    "lodash": "^2.4.1",
+    "lodash": "^3.8.0",
     "yargs": "^3.8.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "graph"
   ],
   "dependencies": {
-    "glob": "^4.3.4",
+    "glob": "^5.0.5",
     "lodash": "^2.4.1",
     "yargs": "^3.8.0"
   },

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Sass Graph
 
-Parses sass and exposes a graph of dependencies
+Parses Sass files in a directory and exposes a graph of dependencies
 
 [![Build Status](https://travis-ci.org/xzyfer/sass-graph.svg?branch=master)](https://travis-ci.org/xzyfer/sass-graph)
 [![npm version](https://badge.fury.io/js/sass-graph.svg)](http://badge.fury.io/js/sass-graph)
@@ -20,24 +20,7 @@ npm install --save-dev sass-graph
 Usage as a Node library:
 
 ```js
-$ node
-> var sassGraph = require('./sass-graph');
-undefined
-> sassGraph.parseDir('tests/fixtures');
-{ index: {,
-    'tests/fixtures/a.scss': {
-        imports: ['b.scss'],
-        importedBy: [],
-    },
-    'tests/fixtures/b.scss': {
-        imports: ['_c.scss'],
-        importedBy: ['a.scss'],
-    },
-    'tests/fixtures/_c.scss': {
-        imports: [],
-        importedBy: ['b/scss'],
-    },
-}}
+var sassGraph = require('./sass-graph');
 ```
 
 Usage as a command line tool:
@@ -45,10 +28,72 @@ Usage as a command line tool:
 The command line tool will parse a graph and then either display ancestors, descendents or both.
 
 ```
-$ ./bin/sassgraph tests/fixtures tests/fixtures/a.scss -d
-tests/fixtures/a.scss
-tests/fixtures/b.scss
-tests/fixtures/_c.scss
+$ ./bin/sassgraph --help
+Usage: bin/sassgraph <command> [options] <dir> [file]
+
+Commands:
+  ancestors    Output the ancestors
+  descendents  Output the descendents
+
+Options:
+  -I, --load-path   Add directories to the sass load path
+  -e, --extensions  File extensions to include in the graph
+  -j, --json        Output the index in json
+  -h, --help        Show help
+  -v, --version     Show version number
+
+Examples:
+  ./bin/sassgraph descendents test/fixtures test/fixtures/a.scss
+  /path/to/test/fixtures/b.scss
+  /path/to/test/fixtures/_c.scss
+```
+
+## API
+
+#### parseDir
+
+Parses a directory and builds a dependency graph of all requested file extensions.
+
+#### parseFile
+
+Parses a file and builds its dependency graph.
+
+## Options
+
+#### loadPaths
+
+Type: `Array`
+Default: `[process.cwd]`
+
+Directories to use when resolved `@import` directives.
+
+#### extensions
+
+Type: `Array`
+Default: `['scss', 'css']`
+
+File types to be parsed.
+
+## Example
+
+```js
+var sassGraph = require('./sass-graph');
+console.log(sassGraph.parseDir('test/fixtures'));
+
+//{ index: {,
+//    '/path/to/test/fixtures/a.scss': {
+//        imports: ['b.scss'],
+//        importedBy: [],
+//    },
+//    '/path/to/test/fixtures/b.scss': {
+//        imports: ['_c.scss'],
+//        importedBy: ['a.scss'],
+//    },
+//    '/path/to/test/fixtures/_c.scss': {
+//        imports: [],
+//        importedBy: ['b/scss'],
+//    },
+//}}
 ```
 
 ## Running Mocha tests

--- a/sass-graph.js
+++ b/sass-graph.js
@@ -49,7 +49,7 @@ function Graph(options, dir) {
     var graph = this;
     _(glob.sync(dir+'/**/*.@('+this.extensions.join('|')+')', { dot: true })).forEach(function(file) {
       graph.addFile(path.resolve(file));
-    });
+    }).value();
   }
 }
 

--- a/sass-graph.js
+++ b/sass-graph.js
@@ -65,14 +65,10 @@ Graph.prototype.addFile = function(filepath, parent) {
   var imports = parseImports(fs.readFileSync(filepath, 'utf-8'));
   var cwd = path.dirname(filepath);
 
-  var i, length = imports.length;
+  var i, length = imports.length, loadPaths, resolved;
   for (i = 0; i < length; i++) {
-    [this.dir, cwd].forEach(function (path) {
-      if (path && this.loadPaths.indexOf(path) === -1) {
-        this.loadPaths.push(path);
-      }
-    }.bind(this));
-    var resolved = resolveSassPath(imports[i], _.uniq(this.loadPaths));
+    loadPaths = _([cwd, this.dir]).concat(this.loadPaths).filter().uniq().value();
+    resolved = resolveSassPath(imports[i], loadPaths, this.extensions);
     if (!resolved) continue;
 
     // recurse into dependencies if not already enumerated

--- a/test/fixtures/i.scss
+++ b/test/fixtures/i.scss
@@ -1,0 +1,1 @@
+.g { color: strawberry; }

--- a/test/test.js
+++ b/test/test.js
@@ -4,24 +4,25 @@ var path = require("path");
 
 var fixtures = path.resolve("test/fixtures");
 var files = {
-  'a.scss': fixtures + "/a.scss",
-  'b.scss': fixtures + "/b.scss",
-  '_c.scss': fixtures + "/_c.scss",
-  'd.scss': fixtures + "/d.scss",
-  '_e.scss': fixtures + "/components/_e.scss",
-  'f.scss': fixtures + "/f.scss",
-  'g.scss': fixtures + "/g.scss",
-  '_h.scss': fixtures + "/nested/_h.scss",
-  '_i.scss': fixtures + "/nested/_i.scss",
-  'j.scss': fixtures + "/j.scss",
-  'k.l.scss': fixtures + "/components/k.l.scss",
-  'm.scss': fixtures + "/m.scss",
-  '_n.scss': fixtures + "/compass/_n.scss",
-  '_compass.scss': fixtures + "/components/_compass.scss"
+  'a.scss': fixtures + '/a.scss',
+  'b.scss': fixtures + '/b.scss',
+  '_c.scss': fixtures + '/_c.scss',
+  'd.scss': fixtures + '/d.scss',
+  '_e.scss': fixtures + '/components/_e.scss',
+  'f.scss': fixtures + '/f.scss',
+  'g.scss': fixtures + '/g.scss',
+  '_h.scss': fixtures + '/nested/_h.scss',
+  '_i.scss': fixtures + '/nested/_i.scss',
+  'i.scss': fixtures + '/_i.scss',
+  'j.scss': fixtures + '/j.scss',
+  'k.l.scss': fixtures + '/components/k.l.scss',
+  'm.scss': fixtures + '/m.scss',
+  '_n.scss': fixtures + '/compass/_n.scss',
+  '_compass.scss': fixtures + '/components/_compass.scss'
 }
 
 describe('sass-graph', function(){
-  var sassGraph = require("../sass-graph");
+  var sassGraph = require('../sass-graph');
 
   describe('parsing a graph of all scss files', function(){
     var graph = sassGraph.parseDir(fixtures, {loadPaths: [fixtures + '/components']});
@@ -58,6 +59,16 @@ describe('sass-graph', function(){
         ancestors.push(k);
       })
       assert.deepEqual([files['b.scss'], files['a.scss']], ancestors);
+    });
+
+    it('should prioritize cwd', function() {
+      var expectedDescendents = [files['_i.scss']];
+      var descendents = [];
+
+      graph.visitDescendents(files['_h.scss'], function (imp) {
+        descendents.push(imp);
+        assert.notEqual(expectedDescendents.indexOf(imp), -1);
+      });
     });
   })
 


### PR DESCRIPTION
This PR tracks the progress of sass-graph 2.0.0.

- [x] replace CLI `--ancestors` and `--descendents` flags with commands
- [x] configurable file extensions (#23)
- [x] prioritize `cwd` when resolving load paths (#12, #13, #21)
- [x]  update changelog
- [x]  update readme

Fixes #12.
Fixes #21.
Closes #13.
Closes #23.