### PR TITLE
Don’t treat directory with extension as file

### DIFF
--- a/sass-graph.js
+++ b/sass-graph.js
@@ -43,7 +43,7 @@ function Graph(options, dir) {
 
   if (dir) {
     var graph = this;
-    _(glob.sync(dir+'/**/*.@('+this.extensions.join('|')+')', { dot: true })).forEach(function(file) {
+    _(glob.sync(dir+'/**/*.@('+this.extensions.join('|')+')', { dot: true, nodir: true })).forEach(function(file) {
       graph.addFile(path.resolve(file));
     }).value();
   }

--- a/test/fixtures/_o.scss/_p.scss
+++ b/test/fixtures/_o.scss/_p.scss
@@ -1,0 +1,1 @@
+.o { color: goldenrod; }

--- a/test/test.js
+++ b/test/test.js
@@ -18,6 +18,7 @@ var files = {
   'k.l.scss': path.join(fixtures, 'components/k.l.scss'),
   'm.scss': path.join(fixtures, 'm.scss'),
   '_n.scss': path.join(fixtures, 'compass/_n.scss'),
+  '_p.scss': path.join(fixtures, '_o.scss/_p.scss'),
   '_compass.scss': path.join(fixtures, 'components/_compass.scss')
 }
 


### PR DESCRIPTION
This PR fixes https://github.com/sass/node-sass/issues/1354

It won’t treat directories which have allowed extensions as files; instead it will skip them [using `nodir` option from node-glob](https://github.com/isaacs/node-glob#options).