### PR TITLE
Don’t resolve Sass path for directories

### DIFF
--- a/sass-graph.js
+++ b/sass-graph.js
@@ -16,7 +16,7 @@ function resolveSassPath(sassPath, loadPaths, extensions) {
   for (i = 0; i < length; i++) {
     for (j = 0; j < extensions.length; j++) {
       scssPath = path.normalize(loadPaths[i] + '/' + sassPathName + '.' + extensions[j]);
-      if (fs.existsSync(scssPath)) {
+      if (fs.existsSync(scssPath) && fs.lstatSync(scssPath).isFile()) {
         return scssPath;
       }
     }
@@ -25,7 +25,7 @@ function resolveSassPath(sassPath, loadPaths, extensions) {
     for (j = 0; j < extensions.length; j++) {
       scssPath = path.normalize(loadPaths[i] + '/' + sassPathName + '.' + extensions[j]);
       partialPath = path.join(path.dirname(scssPath), '_' + path.basename(scssPath));
-      if (fs.existsSync(partialPath)) {
+      if (fs.existsSync(partialPath) && fs.lstatSync(partialPath).isFile()) {
         return partialPath;
       }
     }

--- a/test/fixtures/components/_q.scss/_s.scss
+++ b/test/fixtures/components/_q.scss/_s.scss
@@ -1,0 +1,1 @@
+.s { background: springgreen; }

--- a/test/fixtures/r.scss
+++ b/test/fixtures/r.scss
@@ -1,0 +1,3 @@
+@import 'components/compass';
+@import 'components/q';
+@import 'components/_q.scss/s';

--- a/test/test.js
+++ b/test/test.js
@@ -19,6 +19,8 @@ var files = {
   'm.scss': path.join(fixtures, 'm.scss'),
   '_n.scss': path.join(fixtures, 'compass/_n.scss'),
   '_p.scss': path.join(fixtures, '_o.scss/_p.scss'),
+  'r.scss': path.join(fixtures, 'r.scss'),
+  '_s.scss': path.join(fixtures, 'components/_q.scss/_s.scss'),
   '_compass.scss': path.join(fixtures, 'components/_compass.scss')
 }
 
@@ -52,6 +54,10 @@ describe('sass-graph', function(){
 
     it('should ignore custom imports for m.scss', function() {
       assert.deepEqual([files['_compass.scss'] , files['_n.scss']], graph.index[files['m.scss']].imports);
+    });
+
+    it('should ignore folder "_q.scss" which has allowed extensions (but not it’s children), referenced from r.scss', function() {
+      assert.deepEqual([files['_compass.scss'], files['_s.scss']], graph.index[files['r.scss']].imports);
     });
 
     it('should traverse ancestors of _c.scss', function() {


### PR DESCRIPTION
This is additional check for https://github.com/xzyfer/sass-graph/pull/34.

Unfortunately, first time I didn’t catch this situation so I made another test case for additional check.

If you reference file as `@import` inside some Sass file, `resolveSassPath` won’t differentiate between files and directories. This check does that and just skips those files. If you want to access some style file inside skipped directory, you can explicitly reference it.