### PR TITLE
Replaces existsSync with a try/catch

### DIFF
--- a/sass-graph.js
+++ b/sass-graph.js
@@ -16,18 +16,22 @@ function resolveSassPath(sassPath, loadPaths, extensions) {
   for (i = 0; i < length; i++) {
     for (j = 0; j < extensions.length; j++) {
       scssPath = path.normalize(loadPaths[i] + '/' + sassPathName + '.' + extensions[j]);
-      if (fs.existsSync(scssPath) && fs.lstatSync(scssPath).isFile()) {
-        return scssPath;
-      }
+      try {
+        if (fs.lstatSync(scssPath).isFile()) {
+          return scssPath;
+        }
+      } catch (e) {}
     }
 
     // special case for _partials
     for (j = 0; j < extensions.length; j++) {
       scssPath = path.normalize(loadPaths[i] + '/' + sassPathName + '.' + extensions[j]);
       partialPath = path.join(path.dirname(scssPath), '_' + path.basename(scssPath));
-      if (fs.existsSync(partialPath) && fs.lstatSync(partialPath).isFile()) {
-        return partialPath;
-      }
+      try {
+        if (fs.lstatSync(partialPath).isFile()) {
+          return partialPath;
+        }
+      } catch (e) {}
     }
   }
 


### PR DESCRIPTION
`.existsSync` has been deprecated and `.access` is recommended as replacement. `.access` throws an error if the file does not exist. Since there is a `.lstatSync` call right _after_ the `existsSync` call. `.lstatSync` will also throw an error if the file does not exist, so this PR should work the same as before but. Closes #29 