### PR TITLE
Replace fragile regexes with a tokenizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "glob": "^7.0.0",
     "lodash": "^4.0.0",
+    "scss-tokenizer": "^0.1.2",
     "yargs": "^4.7.1"
   },
   "devDependencies": {

--- a/parse-imports.js
+++ b/parse-imports.js
@@ -1,16 +1,55 @@
+var tokenizer = require('scss-tokenizer');
+
 function parseImports(content) {
-  var importRe = /\@import ([.\s\S]+?);?$/g;
-  var depRe = /["'](.+?)["']/g;
-  var importMatch = {};
-  var depMatch = {};
+  var tokens = tokenizer.tokenize(content);
   var results = [];
-  // strip comments
-  content = new String(content).replace(/\/\*.+?\*\/|\/\/.*(?=[\n\r])/g, '');
-  while ((importMatch = importRe.exec(content)) !== null) {
-    while ((depMatch = depRe.exec(importMatch[1])) !== null) {
-      results.push(depMatch[1]);
+  var tmp = '';
+  var inImport = false;
+  var inParen = false;
+  var prevToken = tokens[0];
+
+  var i, token;
+  for (i = 1; i < tokens.length; i++) {
+    token = tokens[i];
+
+    if (inImport && !inParen && token[0] === 'string') {
+      results.push(token[1]);
     }
+    else if (token[1] === 'import' && prevToken[1] === '@') {
+      if (inImport) {
+        throw new Error('Encountered invalid @import syntax.');
+      }
+
+      inImport = true;
+    }
+    else if (inImport && !inParen && (token[0] === 'ident' || token[0] === '/')) {
+      tmp += token[1];
+    }
+    else if (inImport && !inParen && (token[0] === 'space' || token[0] === 'newline')) {
+      if (tmp !== '') {
+        results.push(tmp);
+        tmp = '';
+      }
+    }
+    else if (inImport && token[0] === ';') {
+      inImport = false;
+
+      if (tmp !== '') {
+        results.push(tmp);
+        tmp = '';
+      }
+    }
+    else if (inImport && token[0] === '(') {
+      inParen = true;
+      tmp = '';
+    }
+    else if (inParen && token[0] === ')') {
+      inParen = false;
+    }
+
+    prevToken = token;
   }
+
   return results;
 }
 


### PR DESCRIPTION
Use `scss-tokenizer` for more accurate parsing of `@import`s.

Fixes #10
Fixes #43
Closes #6
Closes #49