### PR TITLE
Add initial support for indented syntax

### DIFF
--- a/parse-imports.js
+++ b/parse-imports.js
@@ -1,6 +1,6 @@
 var tokenizer = require('scss-tokenizer');
 
-function parseImports(content) {
+function parseImports(content, isIndentedSyntax) {
   var tokens = tokenizer.tokenize(content);
   var results = [];
   var tmp = '';
@@ -16,7 +16,7 @@ function parseImports(content) {
       results.push(token[1]);
     }
     else if (token[1] === 'import' && prevToken[1] === '@') {
-      if (inImport) {
+      if (inImport && !isIndentedSyntax) {
         throw new Error('Encountered invalid @import syntax.');
       }
 
@@ -29,6 +29,10 @@ function parseImports(content) {
       if (tmp !== '') {
         results.push(tmp);
         tmp = '';
+
+        if (isIndentedSyntax) {
+          inImport = false;
+        }
       }
     }
     else if (inImport && token[0] === ';') {
@@ -48,6 +52,10 @@ function parseImports(content) {
     }
 
     prevToken = token;
+  }
+
+  if (tmp !== '') {
+    results.push(tmp);
   }
 
   return results;

--- a/sass-graph.js
+++ b/sass-graph.js
@@ -62,7 +62,8 @@ Graph.prototype.addFile = function(filepath, parent) {
   };
 
   var resolvedParent;
-  var imports = parseImports(fs.readFileSync(filepath, 'utf-8'));
+  var isIndentedSyntax = path.extname(filepath) === '.sass';
+  var imports = parseImports(fs.readFileSync(filepath, 'utf-8'), isIndentedSyntax);
   var cwd = path.dirname(filepath);
 
   var i, length = imports.length, loadPaths, resolved;
@@ -130,7 +131,7 @@ Graph.prototype.visit = function(filepath, callback, edgeCallback, visited) {
 function processOptions(options) {
   return _.assign({
     loadPaths: [process.cwd()],
-    extensions: ['scss', 'css'],
+    extensions: ['scss', 'css', 'sass'],
   }, options);
 }
 

--- a/test/parse-file.js
+++ b/test/parse-file.js
@@ -38,6 +38,37 @@ describe('sass-graph', function(){
       });
     });
 
+    describe('with a simple graph in indented syntax', function() {
+      it('should return a graph', function() {
+        graph().indented().fromFixtureFile('indented-syntax')
+          .assertDecendents([
+            'b.sass',
+            '_c.sass',
+            path.join('nested', '_d.sass'),
+            path.join('nested', '_e.sass'),
+          ])
+          .assertAncestors(path.join('nested', '_e.sass'), [
+            path.join('nested', '_d.sass'),
+            '_c.sass',
+            'b.sass',
+            'index.sass',
+          ])
+          .assertAncestors(path.join('nested', '_d.sass'), [
+            '_c.sass',
+            'b.sass',
+            'index.sass',
+          ])
+          .assertAncestors('_c.sass', [
+            'b.sass',
+            'index.sass',
+          ])
+          .assertAncestors('b.sass', [
+            'index.sass',
+          ])
+          .assertAncestors('index.sass', []);
+      });
+    });
+
     describe('with a graph with loadPaths', function() {
       it.skip('should return a graph', function() {
         var includeFolder = 'inside-load-path';

--- a/test/parse-imports.js
+++ b/test/parse-imports.js
@@ -15,6 +15,18 @@ describe('parse-imports', function () {
     assert.deepEqual(['app'], result);
   });
 
+  it('should parse single import without quotes', function () {
+    var scss = '@import app;';
+    var result = parseImports(scss);
+    assert.deepEqual(['app'], result);
+  });
+
+  it.only('should parse single import without quotes in indented syntax', function () {
+    var scss = '@import app';
+    var result = parseImports(scss, true);
+    assert.deepEqual(['app'], result);
+  });
+
   it('should parse unquoted import', function () {
     var scss = '@import include/app;\n' +
                '@import include/foo,\n' +
@@ -100,12 +112,20 @@ describe('parse-imports', function () {
   });
 
   it('should throw error when invalid @import syntax is encountered', function () {
-    var scss = '@import "a.css"\n' +
-        '@import "b.scss";';
+    var scss = '@import "a"\n' +
+        '@import "b";';
     assert.throws(function() {
       parseImports(scss);
     });
-  })
+  });
+
+  it('should not throw error when invalid @import syntax is encountered using indented syntax', function () {
+    var scss = '@import a\n' +
+        '@import b';
+    assert.doesNotThrow(function() {
+      parseImports(scss, true);
+    });
+  });
 
   it('should parse a full css file', function () {
     var scss = '@import url("a.css");\n' +

--- a/test/util.js
+++ b/test/util.js
@@ -13,25 +13,37 @@ var fixture = function(name) {
 };
 
 var graph = function(opts) {
-  var instance, dir;
+  var instance, dir, isIndentedSyntax;
+
+  function indexFile() {
+    if (isIndentedSyntax) {
+      return 'index.sass';
+    }
+    return 'index.scss';
+  };
 
   return  {
+    indented: function() {
+      isIndentedSyntax = true;
+      return this;
+    },
+
     fromFixtureDir: function(name) {
       dir = fixture(name);
-      instance = sassGraph.parseDir(path.dirname(dir()), opts);
+      instance = sassGraph.parseDir(path.dirname(dir(indexFile())), opts);
       return this;
     },
 
     fromFixtureFile: function(name) {
       dir = fixture(name);
-      instance = sassGraph.parseFile(dir(), opts);
+      instance = sassGraph.parseFile(dir(indexFile()), opts);
       return this;
     },
 
     assertDecendents: function(expected) {
       var actual = [];
 
-      instance.visitDescendents(dir(), function(imp) {
+      instance.visitDescendents(dir(indexFile()), function(imp) {
         actual.push(imp)
       });
 


### PR DESCRIPTION
Indented syntax has two minor difference that are break the current
tokenization

- import paths are unquoted
- import paths are newline terminated not `;` terminated

Part of this landed in #69.

Closes #31