### PR TITLE
Drop support for io.js and Node.js < 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: node_js
 branches: [master]
 node_js:
-  - "0.12"
-  - "0.11"
-  - "0.10"
-  - "iojs"
   - "4"
-  - "5"
+  - "6"
+  - "8"
 after_success: npm run coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file.
 
 ### Tests
 
+### Dependencies
+
+- yargs@^10.0.3
+
 ## [2.2.4]
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 
 ## [next]
+### BREAKING CHANGES
+
+- Drop support for io.js and Node.js < 4.
+
 ### Features
 
 ### Fixes

--- a/bin/sassgraph
+++ b/bin/sassgraph
@@ -41,9 +41,7 @@ var yargs = require('yargs')
       type: 'bool',
     })
 
-    .version(function() {
-      return require('../package').version;
-    })
+    .version()
     .alias('v', 'version')
 
     .help('h')

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "mocha": "^3.2.0",
     "nyc": "^10.2.0"
   },
+  "engines": {
+    "node": ">= 4"
+  },
   "files": [
     "bin",
     "parse-imports.js",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "glob": "^7.0.0",
     "lodash": "^4.0.0",
     "scss-tokenizer": "^0.2.3",
-    "yargs": "^7.0.0"
+    "yargs": "^10.0.3"
   },
   "devDependencies": {
     "assert": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   },
   "devDependencies": {
     "assert": "^1.3.0",
-    "chai": "^3.5.0",
-    "coveralls": "^2.13.0",
-    "mocha": "^3.2.0",
-    "nyc": "^10.2.0"
+    "chai": "^4.1.2",
+    "coveralls": "^3.0.0",
+    "mocha": "^4.0.1",
+    "nyc": "^11.2.1"
   },
   "engines": {
     "node": ">= 4"

--- a/sass-graph.js
+++ b/sass-graph.js
@@ -132,7 +132,7 @@ Graph.prototype.visit = function(filepath, callback, edgeCallback, visited) {
 };
 
 function processOptions(options) {
-  return _.assign({
+  return Object.assign({
     loadPaths: [process.cwd()],
     extensions: ['scss', 'css', 'sass'],
   }, options);


### PR DESCRIPTION
Not sure if you want to take this step, it'd obviously require a major version bump.

Biggest advantage right now is that it unblocks updates on a lot of dependencies and dev dependencies. I bumped all of them in this PR. I also used `Object.assign` instead of lodash's `_.assign`.

There are of course more new language features (`const`/`let` and classes are the obvious ones) that could be used here but I didn't want to clutter the PR too much.