### PR TITLE
Don't include .css imports in the graph by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 branches: [master]
 node_js:
-  - "4"
-  - "6"
-  - "8"
+  - "lts/argon"
+  - "lts/boron"
+  - "lts/carbon"
+  - "9"
 after_success: npm run coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 ## [next]
 ### BREAKING CHANGES
 
-- Drop support for io.js and Node.js < 4.
+- Drop support for io.js and Node.js < 4 (@realityking, #88)
+- Don't add .css imports to the graph by default (@xzyfer, #91)
 
 ### Features
 
@@ -14,7 +15,11 @@ All notable changes to this project will be documented in this file.
 
 ### Dependencies
 
-- yargs@^10.0.3
+- yargs@^10.0.3 (@realityking, #88)
+- chai@^4.1.2 (@realityking, #88)
+- coveralls@^3.0.0 (@realityking, #88)
+- mocha@^4.0.1 (@realityking, #88)
+- nyc@^11.2.1 (@realityking, #88)
 
 ## [2.2.4]
 ### Dependencies

--- a/bin/sassgraph
+++ b/bin/sassgraph
@@ -22,7 +22,7 @@ var yargs = require('yargs')
 
     .option('e', {
       alias: 'extensions',
-      default: ['scss', 'css', 'sass'],
+      default: ['scss', 'sass'],
       describe: 'File extensions to include in the graph',
       type: 'array',
     })

--- a/sass-graph.js
+++ b/sass-graph.js
@@ -134,7 +134,7 @@ Graph.prototype.visit = function(filepath, callback, edgeCallback, visited) {
 function processOptions(options) {
   return Object.assign({
     loadPaths: [process.cwd()],
-    extensions: ['scss', 'css', 'sass'],
+    extensions: ['scss', 'sass'],
   }, options);
 }
 


### PR DESCRIPTION
This non-standard behaviur has been removed from LibSass in 3.6.0,
and Node Sass 5.0.