### PR TITLE
fix(package): update yargs, mocha and nyc

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,14 +21,14 @@
     "glob": "^7.0.0",
     "lodash": "^4.17.11",
     "scss-tokenizer": "^0.3.0",
-    "yargs": "^10.0.3"
+    "yargs": "^12.0.2"
   },
   "devDependencies": {
     "assert": "^1.3.0",
     "chai": "^4.1.2",
     "coveralls": "^3.0.0",
-    "mocha": "^4.0.1",
-    "nyc": "^11.2.1"
+    "mocha": "^5.2.0",
+    "nyc": "^13.1.0"
   },
   "engines": {
     "node": ">= 4"


### PR DESCRIPTION
Update remaining outdated deps. Specially `yargs` is important as the current is vulnerable to DoS https://snyk.io/vuln/npm:mem:20180117

Rel #95