### PR TITLE
Stop a broken symlink from crashing graph creation

### DIFF
--- a/sass-graph.js
+++ b/sass-graph.js
@@ -52,7 +52,9 @@ function Graph(options, dir) {
   if (dir) {
     var graph = this;
     _.each(glob.sync(dir+'/**/*.@('+this.extensions.join('|')+')', { dot: true, nodir: true, follow: this.follow }), function(file) {
-      graph.addFile(path.resolve(file));
+      try {
+        graph.addFile(path.resolve(file));
+      } catch (e) {}
     });
   }
 }


### PR DESCRIPTION
Emacs creates empty symlinks for files which are being edited. If these are encountered by the graph functionality, it crashes (including crashing a webpack-dev-server). I saw elsewhere in the code that stat errors are ignored -- not sure if this is the right approach, but it fixed my issue.