### PR TITLE
Add resolved paths attribute

### DIFF
--- a/sass-graph.js
+++ b/sass-graph.js
@@ -7,17 +7,22 @@ var glob = require('glob');
 var parseImports = require('./parse-imports');
 
 // resolve a sass module to a path
-function resolveSassPath(sassPath, loadPaths, extensions) {
+function resolveSassPath(sassPath, loadPaths, extensions, foundedPaths) {
   // trim sass file extensions
-  var re = new RegExp('(\.('+extensions.join('|')+'))$', 'i');
+  var re = new RegExp('(\.(' + extensions.join('|') + '))$', 'i');
   var sassPathName = sassPath.replace(re, '');
   // check all load paths
-  var i, j, length = loadPaths.length, scssPath, partialPath;
+  var i, j, length = loadPaths.length,
+    scssPath, partialPath;
   for (i = 0; i < length; i++) {
     for (j = 0; j < extensions.length; j++) {
       scssPath = path.normalize(loadPaths[i] + '/' + sassPathName + '.' + extensions[j]);
       try {
         if (fs.lstatSync(scssPath).isFile()) {
+          var sassFileDir = path.normalize(loadPaths[i] + '/');
+          if (foundedPaths.indexOf(sassFileDir) === -1) {
+            foundedPaths.push(sassFileDir);
+          }
           return scssPath;
         }
       } catch (e) {}
@@ -45,13 +50,18 @@ function Graph(options, dir) {
   this.exclude = options.exclude instanceof RegExp ? options.exclude : null;
   this.index = {};
   this.follow = options.follow || false;
-  this.loadPaths = _(options.loadPaths).map(function(p) {
+  this.foundedPaths = [];
+  this.loadPaths = _(options.loadPaths).map(function (p) {
     return path.resolve(p);
   }).value();
 
   if (dir) {
     var graph = this;
-    _.each(glob.sync(dir+'/**/*.@('+this.extensions.join('|')+')', { dot: true, nodir: true, follow: this.follow }), function(file) {
+    _.each(glob.sync(dir + '/**/*.@(' + this.extensions.join('|') + ')', {
+      dot: true,
+      nodir: true,
+      follow: this.follow
+    }), function (file) {
       try {
         graph.addFile(path.resolve(file));
       } catch (e) {}
@@ -60,7 +70,7 @@ function Graph(options, dir) {
 }
 
 // add a sass file to the graph
-Graph.prototype.addFile = function(filepath, parent) {
+Graph.prototype.addFile = function (filepath, parent) {
   if (this.exclude !== null && this.exclude.test(filepath)) return;
 
   var entry = this.index[filepath] = this.index[filepath] || {
@@ -74,10 +84,11 @@ Graph.prototype.addFile = function(filepath, parent) {
   var imports = parseImports(fs.readFileSync(filepath, 'utf-8'), isIndentedSyntax);
   var cwd = path.dirname(filepath);
 
-  var i, length = imports.length, loadPaths, resolved;
+  var i, length = imports.length,
+    loadPaths, resolved;
   for (i = 0; i < length; i++) {
     loadPaths = _([cwd, this.dir]).concat(this.loadPaths).filter().uniq().value();
-    resolved = resolveSassPath(imports[i], loadPaths, this.extensions);
+    resolved = resolveSassPath(imports[i], loadPaths, this.extensions, this.foundedPaths);
     if (!resolved) continue;
 
     // check exclcude regex
@@ -108,23 +119,23 @@ Graph.prototype.addFile = function(filepath, parent) {
 };
 
 // visits all files that are ancestors of the provided file
-Graph.prototype.visitAncestors = function(filepath, callback) {
-  this.visit(filepath, callback, function(err, node) {
+Graph.prototype.visitAncestors = function (filepath, callback) {
+  this.visit(filepath, callback, function (err, node) {
     if (err || !node) return [];
     return node.importedBy;
   });
 };
 
 // visits all files that are descendents of the provided file
-Graph.prototype.visitDescendents = function(filepath, callback) {
-  this.visit(filepath, callback, function(err, node) {
+Graph.prototype.visitDescendents = function (filepath, callback) {
+  this.visit(filepath, callback, function (err, node) {
     if (err || !node) return [];
     return node.imports;
   });
 };
 
 // a generic visitor that uses an edgeCallback to find the edges to traverse for a node
-Graph.prototype.visit = function(filepath, callback, edgeCallback, visited) {
+Graph.prototype.visit = function (filepath, callback, edgeCallback, visited) {
   filepath = fs.realpathSync(filepath);
   var visited = visited || [];
   if (!this.index.hasOwnProperty(filepath)) {
@@ -149,7 +160,7 @@ function processOptions(options) {
   }, options);
 }
 
-module.exports.parseFile = function(filepath, options) {
+module.exports.parseFile = function (filepath, options) {
   if (fs.lstatSync(filepath).isFile()) {
     filepath = path.resolve(filepath);
     options = processOptions(options);
@@ -160,7 +171,7 @@ module.exports.parseFile = function(filepath, options) {
   // throws
 };
 
-module.exports.parseDir = function(dirpath, options) {
+module.exports.parseDir = function (dirpath, options) {
   if (fs.lstatSync(dirpath).isDirectory()) {
     dirpath = path.resolve(dirpath);
     options = processOptions(options);


### PR DESCRIPTION
Hi!

First of all, congrates for the great job into this module.
I'm using your module to found all imports files with dependecies from a less file, but I need something else, a resolved paths without the file name. This change allow me to get all resolved paths prevent me to loop the graph index attribute.

Regards,
José