### PR TITLE
bump yargs to ^15.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "glob": "^7.0.0",
     "lodash": "^4.17.11",
     "scss-tokenizer": "^0.3.0",
-    "yargs": "^12.0.2"
+    "yargs": "^15.3.0"
   },
   "devDependencies": {
     "assert": "^1.3.0",
@@ -31,7 +31,7 @@
     "nyc": "^13.1.0"
   },
   "engines": {
-    "node": ">= 4"
+    "node": ">= 6"
   },
   "files": [
     "bin",


### PR DESCRIPTION
fixes #108

node-sass will need to take a bumped dependency on v3.x.x