### PR TITLE
Bump yargs@^13.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "glob": "^7.0.0",
     "lodash": "^4.0.0",
     "scss-tokenizer": "^0.2.3",
-    "yargs": "^7.0.0"
+    "yargs": "^13.3.2"
   },
   "devDependencies": {
     "assert": "^1.3.0",


### PR DESCRIPTION
This is the earliest version of yargs that patches https://www.npmjs.com/advisories/1500.

This is a BC break for sass-graph because yargs appears to have dropped support for Node < 6, but doesn't break BC for node-sass (the primary consumer) because it does not exercise the CLI.

Not sure how to proceed just yet but want to see what CI thinks.