### PR TITLE
Use individual lodash methods

### DIFF
--- a/sass-graph.js
+++ b/sass-graph.js
@@ -5,9 +5,12 @@ var path = require('path');
 var includes = require('lodash/includes');
 var intersection = require('lodash/intersection');
 var uniq = require('lodash/uniq');
-var filter = require('lodash/filter');
 var glob = require('glob');
 var parseImports = require('./parse-imports');
+
+function identity (value) {
+  return value;
+}
 
 // resolve a sass module to a path
 function resolveSassPath(sassPath, loadPaths, extensions) {
@@ -79,7 +82,7 @@ Graph.prototype.addFile = function(filepath, parent) {
 
   var i, length = imports.length, loadPaths, resolved;
   for (i = 0; i < length; i++) {
-    loadPaths = uniq(filter([cwd, this.dir].concat(this.loadPaths)));
+    loadPaths = uniq([cwd, this.dir].concat(this.loadPaths).filter(identity));
     resolved = resolveSassPath(imports[i], loadPaths, this.extensions);
     if (!resolved) continue;
 

--- a/sass-graph.js
+++ b/sass-graph.js
@@ -7,7 +7,6 @@ var each = require('lodash/each');
 var intersection = require('lodash/intersection');
 var uniq = require('lodash/uniq');
 var filter = require('lodash/filter');
-var concat = require('lodash/concat');
 var glob = require('glob');
 var parseImports = require('./parse-imports');
 
@@ -81,7 +80,7 @@ Graph.prototype.addFile = function(filepath, parent) {
 
   var i, length = imports.length, loadPaths, resolved;
   for (i = 0; i < length; i++) {
-    loadPaths = uniq(filter(concat([cwd, this.dir], this.loadPaths)));
+    loadPaths = uniq(filter([cwd, this.dir].concat(this.loadPaths)));
     resolved = resolveSassPath(imports[i], loadPaths, this.extensions);
     if (!resolved) continue;
 

--- a/sass-graph.js
+++ b/sass-graph.js
@@ -5,7 +5,6 @@ var path = require('path');
 var includes = require('lodash/includes');
 var each = require('lodash/each');
 var intersection = require('lodash/intersection');
-var map = require('lodash/map');
 var uniq = require('lodash/uniq');
 var filter = require('lodash/filter');
 var concat = require('lodash/concat');
@@ -51,7 +50,7 @@ function Graph(options, dir) {
   this.exclude = options.exclude instanceof RegExp ? options.exclude : null;
   this.index = {};
   this.follow = options.follow || false;
-  this.loadPaths = map(options.loadPaths, function(p) {
+  this.loadPaths = (options.loadPaths || []).map(function(p) {
     return path.resolve(p);
   });
 

--- a/sass-graph.js
+++ b/sass-graph.js
@@ -3,7 +3,6 @@
 var fs = require('fs');
 var path = require('path');
 var includes = require('lodash/includes');
-var each = require('lodash/each');
 var intersection = require('lodash/intersection');
 var uniq = require('lodash/uniq');
 var filter = require('lodash/filter');
@@ -55,7 +54,7 @@ function Graph(options, dir) {
 
   if (dir) {
     var graph = this;
-    each(glob.sync(dir+'/**/*.@('+this.extensions.join('|')+')', { dot: true, nodir: true, follow: this.follow }), function(file) {
+    glob.sync(dir+'/**/*.@('+this.extensions.join('|')+')', { dot: true, nodir: true, follow: this.follow }).forEach(function(file) {
       try {
         graph.addFile(path.resolve(file));
       } catch (e) {}


### PR DESCRIPTION
Similarly to how `node-sass` works, this changes the way lodash functions are loaded to only require the specific methods that are actually used by `sass-graph`.

I also went through all the used lodash functions and replaced any with native ES5 functionality where that's available. Once `sass-graph` requires a higher Node.js version more could be eliminated.

With this PR only 3 lodash functions are used:

- `includes` (native replacement available with Node.js 6.4)
- `intersection`
- `uniq`