### PR TITLE
updating the version of yargs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "glob": "^7.0.0",
     "lodash": "^4.17.11",
     "scss-tokenizer": "^0.3.0",
-    "yargs": "^13.3.2"
+    "yargs": "^17.0.1"
   },
   "devDependencies": {
     "assert": "^1.3.0",


### PR DESCRIPTION
the current version of yargs used a version of y18n that has Prototype Pollution
 issues
https://www.npmjs.com/advisories/1654
As mentioned in the abive document this has been resolved in 5.0.5 or later versions of y18n.

yargs version 17.0.1 uses the v5.0.5 of y18n which should resolve this issue